### PR TITLE
Use resolution for glossy in package.json with tz fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "mocha": "^5.2.0",
     "mocha-cakes-2": "^2.0.1",
     "prettier": "^1.15.3"
+  },
+  "resolutions": {
+    "winston-syslog/glossy": "pavkriz/glossy#efb47740b14defcaae289f98f43ae276cccd1a2f"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,10 +666,9 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-glossy@^0.1.7:
+glossy@^0.1.7, glossy@pavkriz/glossy#efb47740b14defcaae289f98f43ae276cccd1a2f:
   version "0.1.7"
-  resolved "https://registry.yarnpkg.com/glossy/-/glossy-0.1.7.tgz#769b5984a96f6066ab9ea758224825ee6c210f0b"
-  integrity sha1-dptZhKlvYGarnqdYIkgl7mwhDws=
+  resolved "https://codeload.github.com/pavkriz/glossy/tar.gz/efb47740b14defcaae289f98f43ae276cccd1a2f"
 
 graceful-fs@^4.1.2:
   version "4.1.11"


### PR DESCRIPTION
There is a bug in glossy (syslog formatter) that causes the date to be
generated in UTC, but with the offset of the local timezone included.
This affects the recorded logs when using the RFC5424 syslog type.
Winston-syslog depends on glossy and there is a partial fix in the
upstream [github repo](squeeks/glossy). However, the year is still wrong and the
fix on github has not been released to npm since 2 years. Manually
resolving the dependency to a fixed git commit seems like a decent
workaround until upstream is fixed and released.