### PR TITLE
Allow actually truncating logs that are too big

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -9,6 +9,6 @@
       "apiKey": "some-api-key",
       "batchSize": 2
     },
-    "handleBigLogs": "too_big"
+    "handleBigLogs": "default"
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -8,6 +8,7 @@
     "datadog": {
       "apiKey": "some-api-key",
       "batchSize": 2
-    }
+    },
+    "handleBigLogs": "too_big"
   }
 }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const splatEntry = require("./lib/splat-entry");
 const stringify = require("./lib/stringify");
 
 const PromTransport = require("./lib/prom-transport");
+const maxMessageLength = 60 * 1024;
 const config = appConfig.logging ?? {};
 
 if (config.truncateLog) {
@@ -38,8 +39,18 @@ function logFilename() {
 }
 
 function truncateTooLong(info) {
-  if (Buffer.byteLength(info.message, "utf8") > 60 * 1024) {
-    info.message = "too big to log";
+  if (Buffer.byteLength(info.message, "utf8") > maxMessageLength) {
+    switch (appConfig.handleBigLogs) {
+      case "truncate":
+        info.message = info.message.substring(0, maxMessageLength);
+        break;
+      case "split":
+        // Do something magic here
+        break;
+      default:
+        info.message = "too big to log";
+        break;
+    }
   }
   return info;
 }

--- a/index.js
+++ b/index.js
@@ -42,10 +42,7 @@ function truncateTooLong(info) {
   if (Buffer.byteLength(info.message, "utf8") > maxMessageLength) {
     switch (appConfig.handleBigLogs) {
       case "truncate":
-        info.message = info.message.substring(0, maxMessageLength);
-        break;
-      case "split":
-        // Do something magic here
+        info.message = `${info.message.substring(0, maxMessageLength - 3)}...`;
         break;
       default:
         info.message = "too big to log";

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ const logger = winston.createLogger({
   colors: logLevel.colors,
   transports: transports,
   exceptionHandlers: [new winston.transports.Console()],
+  rejectionHandlers: [new winston.transports.Console()], // log unhandled promise rejections to stdout
   exitOnError: appConfig.envName !== "production",
   format: format.combine(
     format.metadata({key: "metaData"}),

--- a/lib/splat-entry.js
+++ b/lib/splat-entry.js
@@ -16,13 +16,15 @@ function splatEntry(info) {
     /([\\"]{0,}(x-)?api-key[\\"]{0,}[:=][\\"]{0,})(([\s]?[\\"]?[0-9a-fA-F]){8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})([\\"]{0,})/gi;
   const noAuth = /([\\"]+)auth([\\"]+:)({|\n)([^}]*})/gi;
   const noToken = /(token[s]?[/\\":]+)[a-z0-9-]{36}([/ \\",}]+)/gi;
-  const maskEmail = /([\\"]+[a-z])[^"{}@]+@([a-z0-9.]+[\\"]+)/gi;
+  const noBasicAuth = /(:\/\/[a-z0-9äöå]).+:.+@/gi;
+  const maskEmail = /([\\"]+[a-zäöå])[^"{}@]+@([a-zäöå0-9.]+[\\"]+)/gi;
   const maskName = /([\\"]+(firstName|lastName)[\\"]+:)([\\"]+[a-zäöå])[^"{}]+([\\"]+)/gi;
 
   info.message = util
     .format(info.message, ...message)
     .replace(noapikey, "$1SECRET$6")
     .replace(noAuth, "$1auth$2$1SECRET$1")
+    .replace(noBasicAuth, "$1xxx:SECRET@")
     .replace(noToken, "$1SECRET$2")
     .replace(maskEmail, "$1xxx@$2")
     .replace(maskName, "$1$3xxx$4");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Markus Ekholm",
     "Jens Carlén"
   ],
-  "version": "5.0.1",
+  "version": "5.1.0",
   "engines": {
     "node": ">=16 <=18"
   },

--- a/test/feature/logging-feature.js
+++ b/test/feature/logging-feature.js
@@ -56,7 +56,7 @@ Feature("Logging", () => {
     });
   });
 
-  Scenario("Logging a too big message JSON format, default behaviour", () => {
+  Scenario("Logging a too big message JSON format, default behaviour (in config)", () => {
     const message = "Message".repeat(9000);
     const data = {
       meta: {
@@ -65,6 +65,31 @@ Feature("Logging", () => {
         correlationId: "sample-correlation-id"
       }
     };
+
+    When("logging a huge message", () => {
+      logger.debug(message, data);
+    });
+
+    Then("log output should be a message that it is too big to log", () => {
+      const logContent = transport.logs.shift();
+      logContent.metaData.should.deep.equal(data);
+      logContent.message.should.equal("too big to log");
+    });
+  });
+
+  Scenario("Logging a too big message JSON format, default behaviour (no config)", () => {
+    const message = "Message".repeat(9000);
+    const data = {
+      meta: {
+        createdAt: "2017-09-24-00:00T00:00:00.000Z",
+        updatedAt: "2017-09-24-00:00T00:00:00.000Z",
+        correlationId: "sample-correlation-id"
+      }
+    };
+
+    Given("we have no config for handling big logs", () => {
+      delete config.handleBigLogs;
+    });
 
     When("logging a huge message", () => {
       logger.debug(message, data);

--- a/test/feature/logging-feature.js
+++ b/test/feature/logging-feature.js
@@ -98,33 +98,7 @@ Feature("Logging", () => {
     Then("log output should be the first 60 * 1024 bytes of the message", () => {
       const logContent = transport.logs.shift();
       logContent.metaData.should.deep.equal(data);
-      logContent.message.should.equal(message.substring(0, 60 * 1024));
-    });
-  });
-
-  Scenario.skip("Logging a too big message JSON format, split it up", () => {
-    const message = "Message".repeat(9000);
-    const data = {
-      meta: {
-        createdAt: "2017-09-24-00:00T00:00:00.000Z",
-        updatedAt: "2017-09-24-00:00T00:00:00.000Z",
-        correlationId: "sample-correlation-id"
-      }
-    };
-
-    Given("we want to split big logs", () => {
-      config.handleBigLogs = "split";
-    });
-
-    When("logging a huge message", () => {
-      logger.debug(message, data);
-    });
-
-    Then("log output should be split", () => {
-      const logContent = transport.logs.shift();
-      console.log("logContent :>> ", logContent);
-      logContent.metaData.should.deep.equal(data);
-      logContent.message.should.equal(message);
+      logContent.message.should.equal(`${message.substring(0, 60 * 1024 - 3)}...`);
     });
   });
 

--- a/test/feature/logging-feature.js
+++ b/test/feature/logging-feature.js
@@ -155,6 +155,20 @@ Feature("Logging", () => {
     });
   });
 
+  Scenario("Logging a message including basic auth", () => {
+    const message = "amqp://user:password@example.com/some-path";
+    const data = "some-data";
+
+    When("logging a message with an API Key", () => {
+      logger.debug(message, data);
+    });
+
+    Then("log output should be trimmed", () => {
+      const logContent = transport.logs.shift();
+      logContent.message.should.equal("amqp://uxxx:SECRET@example.com/some-path some-data");
+    });
+  });
+
   Scenario("Logging an auth object as message", () => {
     const message =
       '{"auth":{"user":"some-user","pass":"some-password"},"correlationId":"e91c70da-5156-1234-5678-451e863c1639"}';


### PR DESCRIPTION
Default behaviour is still the old: replace logs that are too big with a message `too big to log`.

Optionally allow a config parameter `handleBigLogs` with a value of `truncate` to truncate logs that are too big instead.

_Sneaked in a masking of basic auth in urls too_