### PR TITLE
Improve lu-logger handling and performance

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,7 +1,7 @@
 require:
   - 'mocha-cakes-2'
   - './test/config/setup.js'
-timeout: 1000
+timeout: 1500
 reporter: 'spec'
 recursive: true
 ui: 'mocha-cakes-2'

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const DatadogTransport = require("./lib/datadog-transport");
 const {getLoc} = require("./lib/get-loc");
 const logLevels = require("./config/levels");
 const splatEntry = require("./lib/splat-entry");
+const cleanEntry = require("./lib/clean-entry");
 const stringify = require("./lib/stringify");
 
 const PromTransport = require("./lib/prom-transport");
@@ -117,8 +118,9 @@ const logger = winston.createLogger({
   exitOnError: appConfig.envName !== "production",
   format: format.combine(
     format.metadata({key: "metaData"}),
-    format(truncateTooLong)(),
     format(splatEntry)(),
+    format(truncateTooLong)(),
+    format(cleanEntry)(),
     format.timestamp(),
     format(logLevel)(),
     format(location)(),

--- a/lib/clean-entry.js
+++ b/lib/clean-entry.js
@@ -1,0 +1,28 @@
+"use strict";
+const config = require("exp-config").logging;
+
+function cleanEntry(info) {
+  const noapikey =
+    /([\\"]{0,}(x-)?api-key[\\"]{0,}[:=][\\"]{0,})(([\s]?[\\"]?[0-9a-fA-F]){8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})([\\"]{0,})/gi;
+  const noAuth = /([\\"]+)auth([\\"]+:)({|\n)([^}]*})/gi;
+  const noToken = /(token[s]?[/\\":]+)[a-z0-9-]{36}([/ \\",}]+)/gi;
+  const noBasicAuth = /(:\/\/[a-z0-9äöå]).+?:.+?@/gi;
+  const maskEmail = /([\\"]+[a-zäöå])[^"{}@]+?@([a-zäöå0-9.]+?[\\"]+)/gi;
+  const maskName = /([\\"]+(firstName|lastName)[\\"]+:)([\\"]+[a-zäöå])[^"{}]+?([\\"]+)/gi;
+
+  info.message = info.message
+    .replace(noapikey, "$1SECRET$6")
+    .replace(noAuth, "$1auth$2$1SECRET$1")
+    .replace(noBasicAuth, "$1xxx:SECRET@")
+    .replace(noToken, "$1SECRET$2")
+    .replace(maskEmail, "$1xxx@$2")
+    .replace(maskName, "$1$3xxx$4");
+
+  if (!config.pretty) {
+    info.message = info.message.replace(/\n\s*/gm, " ");
+  }
+
+  return info;
+}
+
+module.exports = cleanEntry;

--- a/lib/splat-entry.js
+++ b/lib/splat-entry.js
@@ -1,6 +1,5 @@
 "use strict";
 const util = require("util");
-const config = require("exp-config").logging;
 const isEqual = require("lodash.isequal");
 
 function splatEntry(info) {
@@ -12,26 +11,8 @@ function splatEntry(info) {
       info.metaData = message.pop();
     }
   }
-  const noapikey =
-    /([\\"]{0,}(x-)?api-key[\\"]{0,}[:=][\\"]{0,})(([\s]?[\\"]?[0-9a-fA-F]){8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12})([\\"]{0,})/gi;
-  const noAuth = /([\\"]+)auth([\\"]+:)({|\n)([^}]*})/gi;
-  const noToken = /(token[s]?[/\\":]+)[a-z0-9-]{36}([/ \\",}]+)/gi;
-  const noBasicAuth = /(:\/\/[a-z0-9äöå]).+:.+@/gi;
-  const maskEmail = /([\\"]+[a-zäöå])[^"{}@]+@([a-zäöå0-9.]+[\\"]+)/gi;
-  const maskName = /([\\"]+(firstName|lastName)[\\"]+:)([\\"]+[a-zäöå])[^"{}]+([\\"]+)/gi;
 
-  info.message = util
-    .format(info.message, ...message)
-    .replace(noapikey, "$1SECRET$6")
-    .replace(noAuth, "$1auth$2$1SECRET$1")
-    .replace(noBasicAuth, "$1xxx:SECRET@")
-    .replace(noToken, "$1SECRET$2")
-    .replace(maskEmail, "$1xxx@$2")
-    .replace(maskName, "$1$3xxx$4");
-
-  if (!config.pretty) {
-    info.message = info.message.replace(/\n\s*/gm, " ");
-  }
+  info.message = util.format(info.message, ...message);
 
   return info;
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Markus Ekholm",
     "Jens Carlén"
   ],
-  "version": "6.0.2",
+  "version": "6.0.3",
   "engines": {
     "node": ">=16 <=18"
   },

--- a/test/feature/logging-feature.js
+++ b/test/feature/logging-feature.js
@@ -128,7 +128,7 @@ Feature("Logging", () => {
   });
 
   Scenario("Logging a huge message JSON format, truncate it", () => {
-    const message = "{email: test@example.com}".repeat(9000000);
+    const message = "{email: test@example.com}".repeat(9000000); // more than 200MB
     const data = {
       meta: {
         createdAt: "2017-09-24-00:00T00:00:00.000Z",

--- a/test/feature/logging-feature.js
+++ b/test/feature/logging-feature.js
@@ -127,6 +127,45 @@ Feature("Logging", () => {
     });
   });
 
+  Scenario("Logging a huge message JSON format, truncate it", () => {
+    const message = "{email: test@example.com}".repeat(9000000);
+    const data = {
+      meta: {
+        createdAt: "2017-09-24-00:00T00:00:00.000Z",
+        updatedAt: "2017-09-24-00:00T00:00:00.000Z",
+        correlationId: "sample-correlation-id"
+      }
+    };
+
+    Given("we want to truncate big logs", () => {
+      config.handleBigLogs = "truncate";
+    });
+
+    When("logging a huge message", () => {
+      logger.debug(message, data);
+    });
+
+    Then("log output should be the first 60 * 1024 bytes of the message", () => {
+      const logContent = transport.logs.shift();
+      logContent.metaData.should.deep.equal(data);
+      logContent.message.should.equal(`${message.substring(0, 60 * 1024 - 3)}...`);
+    });
+  });
+
+  Scenario("Logging an error", () => {
+    const message = "Message";
+    const data = new Error("It's broken");
+
+    When("logging a message containing an error", () => {
+      logger.debug(message, data);
+    });
+
+    Then("log output should include the whole error", () => {
+      const logContent = transport.logs.shift();
+      logContent.message.should.include("Message It's broken Error: It's broken");
+    });
+  });
+
   Scenario("Logging an api-key", () => {
     const message = "Message";
     const data = "x-api-key:8a1ba457-24bc-4941-b136-d401a717c223";
@@ -166,6 +205,20 @@ Feature("Logging", () => {
     Then("log output should be trimmed", () => {
       const logContent = transport.logs.shift();
       logContent.message.should.equal("amqp://uxxx:SECRET@example.com/some-path some-data");
+    });
+  });
+
+  Scenario("Logging a message including basic auth and an email", () => {
+    const message = "amqp://user:password@example.com/some-path";
+    const data = '{"email":"test@example.com"}';
+
+    When("logging a message with an API Key", () => {
+      logger.debug(message, data);
+    });
+
+    Then("log output should be trimmed", () => {
+      const logContent = transport.logs.shift();
+      logContent.message.should.equal('amqp://uxxx:SECRET@example.com/some-path {"email":"txxx@example.com"}');
     });
   });
 


### PR DESCRIPTION
- Add test for huge data
- Add test for Error in data
- Add test with both basic auth and email
- Fix regex when both basic auth and email are in message
- Split out splat and clean to separate functions
- Move splat first, then truncate, then clean (slower than truncate first, but robust enough to handle Error in message)